### PR TITLE
fixed from files docker-compose.yml

### DIFF
--- a/src/Console/Commands/SailInstallCommand.php
+++ b/src/Console/Commands/SailInstallCommand.php
@@ -37,7 +37,7 @@ class SailInstallCommand extends Command
      */
     public function handle()
     {
-	copy(base_path('vendor/laravel/sail/stubs/docker-compose.yml'), base_path('docker-compose.yml'));
+	copy(base_path('vendor/laravel/sail/stubs/docker-compose.stub'), base_path('docker-compose.yml'));
 	copy(__DIR__ . '/../../../stubs/server.php', base_path('server.php'));
 
         $environment = file_get_contents(base_path('.env'));


### PR DESCRIPTION
Fixed bug fixes when we want to use ```php artisan sail: install``` command where "copy ({path/project}/vendor/laravel/sail/stubs/docker-compose.yml) error appears: Failed to open stream: No such file or directory "